### PR TITLE
improve CreatePublicKeyCredentialDomException error reporting

### DIFF
--- a/android/src/main/kotlin/com/authentrend/flutter_passkey/FlutterPasskeyPlugin.kt
+++ b/android/src/main/kotlin/com/authentrend/flutter_passkey/FlutterPasskeyPlugin.kt
@@ -21,6 +21,7 @@ import io.flutter.plugin.common.MethodChannel.Result
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 import java.security.InvalidParameterException
+import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
 
 /** FlutterPasskeyPlugin */
 class FlutterPasskeyPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, ViewModel() {
@@ -103,7 +104,11 @@ class FlutterPasskeyPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, Vie
               result.success(credential)
             }
             else if (e != null) {
-              result.error(e.javaClass.kotlin.simpleName ?: "Exception", e.message ?: "Exception occurred", null)
+              var exceptionType = e.javaClass.kotlin.simpleName
+              if (e is CreatePublicKeyCredentialDomException) {
+                  exceptionType = e.domError.javaClass.kotlin.simpleName
+              }
+              result.error(exceptionType ?: "Exception", e.message ?: "Exception occurred", null)
             }
             else {
               result.error("Error", "Unknown error", null)


### PR DESCRIPTION
If a [CreatePublicKeyCredentialDomException](https://developer.android.com/reference/androidx/credentials/exceptions/publickeycredential/CreatePublicKeyCredentialDomException) is raised, report the exception class as the class of its domError attribute, which can be any of the following instances of [DomError](https://developer.android.com/reference/androidx/credentials/exceptions/domerrors/DomError):

> AbortError, ConstraintError, DataCloneError, DataError, EncodingError, HierarchyRequestError, InUseAttributeError, InvalidCharacterError, InvalidModificationError, InvalidNodeTypeError, InvalidStateError, NamespaceError, NetworkError, NoModificationAllowedError, NotAllowedError, NotFoundError, NotReadableError, NotSupportedError, OperationError, OptOutError, QuotaExceededError, ReadOnlyError, SecurityError, SyntaxError, TimeoutError, TransactionInactiveError, UnknownError, VersionError, WrongDocumentError

For example, if the RPID is different than the origin then registration/authentication fails. Without this change, we'd see the following error:

```
PlatformException(CreatePublicKeyCredentialDomException, The incoming request cannot be validated, null, null)
```

With this change, we see:

```
PlatformException(SecurityError, The incoming request cannot be validated, null, null)
```

This helps debugging problems