### PR TITLE
Upgrade androidx.credentials to 1.2.0-alpha05

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,9 +47,9 @@ android {
 
 dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1"
-    implementation "androidx.credentials:credentials:1.0.0-alpha03"
+    implementation "androidx.credentials:credentials:1.2.0-alpha05"
 
     // optional - needed for credentials support from play services, for devices running
     // Android 13 and below.
-    implementation "androidx.credentials:credentials-play-services-auth:1.0.0-alpha03"
+    implementation "androidx.credentials:credentials-play-services-auth:1.2.0-alpha05"
 }

--- a/android/src/main/kotlin/com/authentrend/flutter_passkey/FlutterPasskeyPlugin.kt
+++ b/android/src/main/kotlin/com/authentrend/flutter_passkey/FlutterPasskeyPlugin.kt
@@ -49,8 +49,8 @@ class FlutterPasskeyPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, Vie
       try {
         val credentialManager = CredentialManager.create(activity!!)
         val result = credentialManager.createCredential(
+          context = activity!!,
           request = createPublicKeyCredentialRequest,
-          activity = activity!!,
         )
         val credential = result as CreatePublicKeyCredentialResponse
         callback(credential.registrationResponseJson, null)
@@ -66,15 +66,14 @@ class FlutterPasskeyPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, Vie
     }
     JSONObject(options) // check if options is a valid json string
     val getPublicKeyCredentialOption = GetPublicKeyCredentialOption(
-      requestJson = options,
-      preferImmediatelyAvailableCredentials = false
+      requestJson = options
     )
     viewModelScope.launch {
       try {
         val credentialManager = CredentialManager.create(activity!!)
         val result = credentialManager.getCredential(
+          context = activity!!,
           request = GetCredentialRequest(listOf(getPublicKeyCredentialOption)),
-          activity = activity!!,
         )
         val credential = result.credential as PublicKeyCredential
         callback(credential.authenticationResponseJson, null)


### PR DESCRIPTION
Upgrade androidx.credentials (credentials and credentials-play-services-auth) to v1.2.0-alpha05. 

This fixes a bug on Android where the allowedCredentials from the server are ignored and all passkeys are presented to the user.